### PR TITLE
Implement respond_to?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fittings (0.2.1)
+    fittings (0.2.2)
 
 GEM
   remote: http://rubygems.org/

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "0.2.1"
+  s.version = "0.2.2"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -71,6 +71,11 @@ class Setting
     end
   end
 
+  def self.respond_to?(method_name, include_private = false)
+    self.instance.available_settings.has_key?(method_name.to_s.sub(/\?\z/, '')) ||
+      super
+  end
+
   # In [] invocation syntax, we return settings value 'as is' without
   # Hash conversions.
   #

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -14,6 +14,7 @@ describe Setting do
     it 'should return test specific values' do
       expect(subject.available_settings['one']).to eq("test")
       expect(subject.one).to eq("test")
+      expect(subject.respond_to?(:one)).to eq(true)
       expect(subject['one']).to eq("test")
     end
 
@@ -37,6 +38,7 @@ describe Setting do
     end
 
     it "should responds to ? mark" do
+      expect(subject.respond_to?(:autologin?)).to eq(true)
       expect(subject.autologin?).to eq(true)
     end
 
@@ -79,6 +81,7 @@ describe Setting do
     end
 
     it 'should support [] syntax' do
+      expect(subject.respond_to?(:[])).to eq(true)
       expect(subject['tax']['default']).to eq(0.0)
       expect(subject['tax']).to eq({ 'default' => 0.0, 'california' => 7.5 })
     end


### PR DESCRIPTION
I ran into this while trying to set up a message expecation in RSpec and
I got a failure because RSpec thought that the `Setting` object wouldn't
respond to the attribute I was attempting to stub.

Further reading:
https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding