### PR TITLE
Update CODEOWNERS and owners.json to runtime-infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
 # https://help.github.com/articles/about-codeowners/
 
-* @stitchfix/devex
+* @stitchfix/runtime-infrastructure

--- a/owners.json
+++ b/owners.json
@@ -1,7 +1,7 @@
 {
   "owners": [
     {
-      "team": "devex"
+      "team": "runtime-infrastructure"
     }
   ]
 }


### PR DESCRIPTION
## PROBLEM
This gem is now owned by the Runtime Infrastructure team.

## SOLUTION
* Update `CODEOWNERS`
* Update `owners.json`