### PR TITLE
Fix threading exception within specs

### DIFF
--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -63,12 +63,21 @@ describe Setting do
   end
 
   context "When running with threads" do
+    before :each do
+      subject.reload(
+         :path  => File.join(File.dirname(__FILE__)) + '/fixtures',
+         :files => ['sample.yml']
+      )
+    end
+
     it "should keep its values" do
-      3.times do |time|
+      thread_settings = 3.times.map {
         Thread.new {
-          expect(subject.available_settings).not_to be_empty
+          subject.available_settings
         }
-      end
+      }.each(&:join).map(&:value)
+
+      expect(thread_settings.any?(&:empty?)).to be false
     end
   end
 


### PR DESCRIPTION
## Problem

Fix threading exception within specs

When the threading spec was the first spec executed in the suite the Settings weren't loaded, causing periodic failures. Ensure they are always populated using a before block.

Depending on the Ruby configuration exceptions raised within the thread would be ignored reporting a successful spec run.

    #<Thread:0x00007f89c691d500 /fittings/spec/mc_settings_spec.rb:68 run> terminated with exception (report_on_exception is true):
    Traceback (most recent call last):
            ... snip ...
    ruby/2.7.2/gems/rspec-support-3.10.0/lib/rspec/support.rb:97:in `block in <module:Support>': expected `{}.empty?` to be falsey, got true (RSpec::Expectations::ExpectationNotMetError)

## Solution

- Ensure Setting is always loaded before running the thread spec
- Adjust expectation to avoid raising RSpec exceptions within the thread
