### PR TITLE
use unsafe load to allow dates in rails 6.1 apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ pkg
 .idea
 .rvmrc
 Gemfile.lock
+
+## VS Code and extensions
+.history
+.vscode

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -180,7 +180,7 @@ class Setting
 
     files.flatten.each do |file|
       begin
-        @available_settings.recursive_merge!(YAML::load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+        @available_settings.recursive_merge!(YAML::unsafe_load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
       rescue Exception => e
         raise FileError.new("Error parsing file #{file}, with: #{e.message}")
       end


### PR DESCRIPTION
## Problem

In psych 4.0 + the `load` alias references `safe_load` instead of `unsafe_load`.   This breaks loading `default.yml` files with dates in them, since `safe_load` only allows a few specified classes (not including `Date`).

Unsafe load should be fine since we're always generating default.yml in house.

## Solution

Use YAML::unsafe_load instead of YAML::load.