### PR TITLE
manually bump version

### DIFF
--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "0.2.2"
+  s.version = "0.2.3"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}


### PR DESCRIPTION
## Problem

This gem doesn't have the `rake version:*` task, so we have to bump the version manually before release.

## Solution

Bump the version.