### PR TITLE
Support Ruby < 3.0.3 as we still support 2.7 for a few more months

### DIFF
--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -180,7 +180,14 @@ class Setting
 
     files.flatten.each do |file|
       begin
-        @available_settings.recursive_merge!(YAML::unsafe_load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+        # Ruby versions before 3.0.3 include Psych < 3.3.2, which does not include `unsafe_load`. In those versions,
+        # `load` is the behavior we want (in later versions, `load` uses `safe_load`, which doesn't support aliases and
+        # requires allowlisting classes used in files.
+        if Psych::VERSION < '3.3.2'
+          @available_settings.recursive_merge!(YAML::load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+        else
+          @available_settings.recursive_merge!(YAML::unsafe_load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+        end
       rescue Exception => e
         raise FileError.new("Error parsing file #{file}, with: #{e.message}")
       end


### PR DESCRIPTION
 `unsafe_load` doesn't exist in Psych < 3.3.2, which is in any ruby version less that 3.0.3. Luckily, `load` in ruby < 3.0.3 behaves as `unsafe_load` does in later versions, so use it in those cases.
