### PR TITLE
Wrap YAML in Hashie::Mash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Switched to using `Hashie::Mash` for YAML parsing. This provides behavior that is more consistent, while remaining similar. It did not cause any tests to fail, but may be a breaking change depending on how you are using the gem.

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "hashie"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -55,6 +55,16 @@ describe Setting do
       expect(subject.test_specific).to eq("exist")
     end
 
+    it "behaves uniformly, regardless of access pattern" do
+      expect(subject.two(:three)).to eq(5)
+      expect(subject.two('three')).to eq(5)
+      expect(subject.two[:three]).to eq(5)
+      expect(subject.two['three']).to eq(5)
+      expect(subject[:two][:three]).to eq(5)
+      expect(subject['two'][:three]).to eq(5)
+      expect(subject[:two]['three']).to eq(5)
+    end
+
     context "working with arrays" do
       it "should replace the whole array instead of appending new values" do
         expect(subject.nested_array).to eq(['first', 'four', 'five'])


### PR DESCRIPTION
Resolves https://github.com/stitchfix/fittings/issues/25

## Problem

`Setting` had different behavior depending on the access pattern. Sometimes it was more forgiving than Ruby, other times it was not.

```ruby
Setting[:foo] # yes
Setting['foo'] # yes
Setting.foo('bar') # yes
Setting.foo(:bar) # yes
Setting.foo['bar'] # yes

Setting.foo[:bar] # no, returns `nil`
```

## Solution

By wrapping the YAML in Hashie::Mashie, we can avoid breaking any existing tests while improving the behavior consistency. Because this may break how folks are using the gem, it should be released as a breaking change.
