### PR TITLE
Return a hash with indifferent access rather than a Mash

### DIFF
--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -8,6 +8,12 @@ class Setting
   class FileError < RuntimeError; end
   class AlreadyLoaded < RuntimeError; end
 
+  class SettingHash < Hash
+    include Hashie::Extensions::IndifferentAccess
+    include Hashie::Extensions::KeyConversion
+    include Hashie::Extensions::DeepMerge
+  end
+
   include Singleton
   NUM_KLASS = if RUBY_VERSION.split(/\./)[0].to_i == 2 && RUBY_VERSION.split(/\./)[1].to_i >= 4
                 Integer
@@ -87,7 +93,7 @@ class Setting
   #=================================================================
 
   def initialize
-    @available_settings ||= Hashie::Mash.new
+    @available_settings ||= SettingHash.new
   end
 
   def has_key?(key)
@@ -105,6 +111,9 @@ class Setting
     end
 
     v = @available_settings[name]
+    if v.is_a?(Hash)
+      v = SettingHash[v]
+    end
     if block_given?
       v = yield(v, args)
     end
@@ -151,7 +160,7 @@ class Setting
 
   def load(params)
     # reset settings hash
-    @available_settings = Hashie::Mash.new
+    @available_settings = SettingHash.new
     @loaded = false
 
     files = []

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -63,6 +63,7 @@ describe Setting do
       expect(subject[:two][:three]).to eq(5)
       expect(subject['two'][:three]).to eq(5)
       expect(subject[:two]['three']).to eq(5)
+      expect(subject[:two].symbolize_keys[:three]).to eq(5)
     end
 
     context "working with arrays" do


### PR DESCRIPTION
## Problem

1.0.0 resolved #25, but `Hashie::Mash` is very different from a regular `Hash`. This causes issues with some existing code. In particular, [`symbolize_keys`](https://github.com/stitchfix/shippinglabels/blob/4869419e691e4fe304541367aefba21e4065ae43/app/services/shipping_label_generators/meta_pack.rb#L12) no longer works as expected.

## Solution

Instead of converting the Setting hash into a `Hashie::Mash`, instead convert returned values that would be a `Hash` into a new `SettingHash` class. This is a normal `Hash` that has had some Hashie extensions added, notably `IndifferentAccess`.

Note that if this gem depended on ActiveSupport, I would just call `.with_indifferent_access` rather than messing with Hashie. It might be worth discussing changing the dependency.
