### PR TITLE
remove reference to Fixnum (removed in Ruby 3.2)

### DIFF
--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "1.1.0.RC1"
+  s.version = "1.1.0"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = ">= 2.4.0"
   s.add_dependency "hashie"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "1.0.0"
+  s.version = "1.1.0.RC1"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -15,11 +15,6 @@ class Setting
   end
 
   include Singleton
-  NUM_KLASS = if RUBY_VERSION.split(/\./)[0].to_i == 2 && RUBY_VERSION.split(/\./)[1].to_i >= 4
-                Integer
-              else
-                Fixnum
-              end
 
   attr_reader :available_settings
 
@@ -119,7 +114,7 @@ class Setting
     end
 
 
-    if v.is_a?(NUM_KLASS) && bool
+    if v.is_a?(Integer) && bool
       v.to_i > 0
     else
       v

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -174,9 +174,9 @@ class Setting
         # `load` is the behavior we want (in later versions, `load` uses `safe_load`, which doesn't support aliases and
         # requires allowlisting classes used in files.
         if Psych::VERSION < '3.3.2'
-          @available_settings.deep_merge!(YAML::load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+          @available_settings.deep_merge!(YAML::load(ERB.new(IO.read(file)).result) || {}) if File.exist?(file)
         else
-          @available_settings.deep_merge!(YAML::unsafe_load(ERB.new(IO.read(file)).result) || {}) if File.exists?(file)
+          @available_settings.deep_merge!(YAML::unsafe_load(ERB.new(IO.read(file)).result) || {}) if File.exist?(file)
         end
       rescue Exception => e
         raise FileError.new("Error parsing file #{file}, with: #{e.message}")

--- a/spec/support/settings_helper.rb
+++ b/spec/support/settings_helper.rb
@@ -48,8 +48,8 @@ CONTENT
       default: "seven from custom"
   CONTENT
 
-  allow(File).to receive(:exists?).and_return(true)
-  allow(File).to receive(:exists?).with("config/settings/environments/development.yml").and_return(false)
+  allow(File).to receive(:exist?).and_return(true)
+  allow(File).to receive(:exist?).with("config/settings/environments/development.yml").and_return(false)
   allow(IO).to receive(:read).with("config/settings/default.yml").and_return(defaults)
   allow(IO).to receive(:read).with("config/settings/environments/test.yml").and_return(test)
   allow(IO).to receive(:read).with("config/settings/local/custom.yml").and_return(custom)


### PR DESCRIPTION
## Problems

* `Fixnum` is [removed](https://bugs.ruby-lang.org/issues/12005) from Ruby 3.2+
* `File.exists?` is [removed](https://bugs.ruby-lang.org/issues/17391) from Ruby 3.2+

## Solution

* remove reference and broken check for the use of Fixnum
* Replace `File.exists?` with `File.exist?`
* bump Ruby requirement for the gem to 2.4+

