### PR TITLE
Revert to Hashie::Mash-based implementation

### DIFF
--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -8,12 +8,6 @@ class Setting
   class FileError < RuntimeError; end
   class AlreadyLoaded < RuntimeError; end
 
-  class SettingHash < Hash
-    include Hashie::Extensions::IndifferentAccess
-    include Hashie::Extensions::KeyConversion
-    include Hashie::Extensions::DeepMerge
-  end
-
   include Singleton
 
   attr_reader :available_settings
@@ -88,7 +82,7 @@ class Setting
   #=================================================================
 
   def initialize
-    @available_settings ||= SettingHash.new
+    @available_settings ||= Hashie::Mash.new
   end
 
   def has_key?(key)
@@ -106,9 +100,6 @@ class Setting
     end
 
     v = @available_settings[name]
-    if v.is_a?(Hash)
-      v = SettingHash[v]
-    end
     if block_given?
       v = yield(v, args)
     end
@@ -155,7 +146,7 @@ class Setting
 
   def load(params)
     # reset settings hash
-    @available_settings = SettingHash.new
+    @available_settings = Hashie::Mash.new
     @loaded = false
 
     files = []

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -82,7 +82,7 @@ class Setting
   #=================================================================
 
   def initialize
-    @available_settings ||= Hashie::Mash.new
+    @available_settings ||= Hashie::Mash.quiet(:default).new
   end
 
   def has_key?(key)
@@ -146,7 +146,7 @@ class Setting
 
   def load(params)
     # reset settings hash
-    @available_settings = Hashie::Mash.new
+    @available_settings = Hashie::Mash.quiet(:default).new
     @loaded = false
 
     files = []

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -63,7 +63,6 @@ describe Setting do
       expect(subject[:two][:three]).to eq(5)
       expect(subject['two'][:three]).to eq(5)
       expect(subject[:two]['three']).to eq(5)
-      expect(subject[:two].symbolize_keys[:three]).to eq(5)
     end
 
     context "working with arrays" do

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -11,16 +11,6 @@ describe Setting do
           :local => true)
     end
 
-    it 'should access via ... something' do
-      expect(Setting.two[:three]).to eq(5)
-      expect(Setting.two['three']).to eq(5)
-      expect(Setting.two.fetch(:three)).to eq(5)
-      expect(Setting.two.fetch('three')).to eq(5)
-      expect(Setting.two).to be_a_kind_of(Hashie::Mash)
-      expect(Setting.two.keys).to eq(["three", "four"])
-      expect(Setting.two).to have_key(:three)
-    end
-
     it 'should return test specific values' do
       expect(subject.available_settings['one']).to eq("test")
       expect(subject.one).to eq("test")
@@ -66,6 +56,9 @@ describe Setting do
     end
 
     it "behaves uniformly, regardless of access pattern" do
+      expect(subject.two).to be_a_kind_of(Hashie::Mash)
+      expect(subject.two.keys).to eq(["three", "four"])
+      expect(subject.two).to have_key(:three)
       expect(subject.two(:three)).to eq(5)
       expect(subject.two('three')).to eq(5)
       expect(subject.two[:three]).to eq(5)
@@ -73,6 +66,8 @@ describe Setting do
       expect(subject[:two][:three]).to eq(5)
       expect(subject['two'][:three]).to eq(5)
       expect(subject[:two]['three']).to eq(5)
+      expect(subject.two.fetch(:three)).to eq(5)
+      expect(subject.two.fetch('three')).to eq(5)
     end
 
     context "working with arrays" do

--- a/spec/mc_settings_spec.rb
+++ b/spec/mc_settings_spec.rb
@@ -11,6 +11,16 @@ describe Setting do
           :local => true)
     end
 
+    it 'should access via ... something' do
+      expect(Setting.two[:three]).to eq(5)
+      expect(Setting.two['three']).to eq(5)
+      expect(Setting.two.fetch(:three)).to eq(5)
+      expect(Setting.two.fetch('three')).to eq(5)
+      expect(Setting.two).to be_a_kind_of(Hashie::Mash)
+      expect(Setting.two.keys).to eq(["three", "four"])
+      expect(Setting.two).to have_key(:three)
+    end
+
     it 'should return test specific values' do
       expect(subject.available_settings['one']).to eq("test")
       expect(subject.one).to eq("test")


### PR DESCRIPTION
## Problem

The 2.x release switched from a Hashie::Mash-based implementation to using Hashie extensions, but this resulted in changed behavior such that chained method calls no longer worked. Since 1.x increased flexibility, we should not reduce that in a newer release.

## Solution

Restore the 1.0.0 implementation while preserving minor syntactic updates to support Ruby 3.2.

One other potentially controversial (!) addition is the use of `quiet(:default)` since otherwise Hashie warnings abound due to the use of a `default` key (which is central to the operation of this library's handling of method-invocation syntax).