### PR TITLE
bump hashie requirement to account for Mash.quiet (zorab47)

### DIFF
--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.4.0"
-  s.add_dependency "hashie"
+  s.add_dependency("hashie", ">= 4.0")
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
## Problem

In https://github.com/stitchfix/fittings/pull/31#discussion_r1062519613, @zorab47 notes that `Hashie::Mash.quiet` was added in [Hashie 4.0](https://github.com/hashie/hashie/releases/tag/v4.0.0). 

## Solution

Require Hashie >= 4.0.