### PR TITLE
Make Hashie >= 4.0 optional

### DIFF
--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "3.0.2.RC1"
+  s.version = "3.0.2"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.4.0"
-  s.add_dependency("hashie", ">= 4.0")
+  s.add_dependency("hashie")
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"

--- a/fittings.gemspec
+++ b/fittings.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "fittings"
-  s.version = "3.0.1"
+  s.version = "3.0.2.RC1"
 
   s.authors = ["Edwin Cruz", "Colin Shield"]
   s.date = %q{2011-09-06}

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -82,7 +82,7 @@ class Setting
   #=================================================================
 
   def initialize
-    @available_settings ||= Hashie::Mash.quiet(:default).new
+    @available_settings ||= new_available_settings
   end
 
   def has_key?(key)
@@ -146,7 +146,7 @@ class Setting
 
   def load(params)
     # reset settings hash
-    @available_settings = Hashie::Mash.quiet(:default).new
+    @available_settings = new_available_settings
     @loaded = false
 
     files = []
@@ -176,5 +176,15 @@ class Setting
 
     @loaded = true
     @available_settings
+  end
+
+  private 
+
+  def new_available_settings
+    if Hashie::Mash.respond_to?(:quiet)
+      Hashie::Mash.quiet(:default).new
+    else
+      Hashie::Mash.new
+    end
   end
 end

--- a/lib/setting.rb
+++ b/lib/setting.rb
@@ -181,6 +181,9 @@ class Setting
   private 
 
   def new_available_settings
+    # Spectre and other monoliths are tied to Hashie 3.x
+    # so once that isn't a problem and all apps can use Hashie >= 4.0
+    # then then Hashie::Mash.quiet can become the default.
     if Hashie::Mash.respond_to?(:quiet)
       Hashie::Mash.quiet(:default).new
     else


### PR DESCRIPTION
## Problem

Spectre uses resque-status that in turn uses github_api that requires Hashie ~> 3.5. v3.0.0 is breaking the build in Spectre.

## Solution

Make the usage of Hashie 4.0 optional.
